### PR TITLE
feat: Phase 3 - Undo/Redo, Save/Load, Font Selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>3D Garment Designer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Black+Han+Sans&family=Noto+Sans+KR:wght@400;700&family=Oswald:wght@400;700&family=Permanent+Marker&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import Scene from "./components/canvas/Scene";
 import Toolbar from "./components/ui/Toolbar";
 import TextPanel from "./components/ui/TextPanel";
@@ -20,7 +20,25 @@ export default function App() {
   const elements = useDesignStore((s) => s.elements);
   const setViewSide = useUIStore((s) => s.setViewSide);
 
+  const undo = useDesignStore((s) => s.undo);
+  const redo = useDesignStore((s) => s.redo);
   const selectedEl = elements.find((el) => el.id === selectedId);
+
+  // Keyboard shortcuts: Ctrl+Z / Ctrl+Y
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      }
+      if ((e.metaKey || e.ctrlKey) && (e.key === "y" || (e.key === "z" && e.shiftKey))) {
+        e.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [undo, redo]);
 
   const handleRendererReady = useCallback((gl: WebGLRenderer) => {
     glRef.current = gl;

--- a/src/components/ui/TextPanel.tsx
+++ b/src/components/ui/TextPanel.tsx
@@ -3,6 +3,17 @@ import { Plus } from "lucide-react";
 import { useDesignStore } from "../../store/useDesignStore";
 import { useUIStore } from "../../store/useUIStore";
 
+const FONT_OPTIONS = [
+  { value: "Arial", label: "Arial" },
+  { value: "'Noto Sans KR'", label: "Noto Sans KR" },
+  { value: "'Playfair Display'", label: "Playfair Display" },
+  { value: "'Bebas Neue'", label: "Bebas Neue" },
+  { value: "'Permanent Marker'", label: "Permanent Marker" },
+  { value: "'Black Han Sans'", label: "Black Han Sans" },
+  { value: "'Oswald'", label: "Oswald" },
+  { value: "monospace", label: "Monospace" },
+];
+
 export default function TextPanel() {
   const activePanel = useUIStore((s) => s.activePanel);
   const addText = useDesignStore((s) => s.addText);
@@ -12,6 +23,7 @@ export default function TextPanel() {
   const [fontSize, setFontSize] = useState(48);
   const [color, setColor] = useState("#ffffff");
   const [fontWeight, setFontWeight] = useState<"normal" | "bold">("bold");
+  const [fontFamily, setFontFamily] = useState("Arial");
 
   if (activePanel !== "text") return null;
 
@@ -22,6 +34,7 @@ export default function TextPanel() {
       fontSize,
       color,
       fontWeight,
+      fontFamily,
       side: viewSide === "back" ? "back" : "front",
     });
     setText("");
@@ -40,6 +53,22 @@ export default function TextPanel() {
           placeholder="Enter text..."
           className="w-full px-3 py-2 rounded-md bg-[#0a0a0a] border border-[#2a2a2a] text-white text-sm placeholder-gray-500 focus:outline-none focus:border-indigo-500"
         />
+
+        {/* Font selector */}
+        <div>
+          <label className="text-xs text-gray-400 mb-1 block">Font</label>
+          <select
+            value={fontFamily}
+            onChange={(e) => setFontFamily(e.target.value)}
+            className="w-full px-3 py-1.5 rounded-md bg-[#0a0a0a] border border-[#2a2a2a] text-white text-sm focus:outline-none focus:border-indigo-500"
+          >
+            {FONT_OPTIONS.map((f) => (
+              <option key={f.value} value={f.value} style={{ fontFamily: f.value }}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+        </div>
 
         <div className="flex gap-2">
           <div className="flex-1">

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -10,8 +10,13 @@ import {
   ArrowLeft,
   ArrowRight,
   Scissors,
+  Undo2,
+  Redo2,
+  Save,
+  FolderOpen,
 } from "lucide-react";
 import { useGarmentStore } from "../../store/useGarmentStore";
+import { useDesignStore } from "../../store/useDesignStore";
 import { useUIStore } from "../../store/useUIStore";
 import { FABRIC_CATALOG } from "../../lib/fabric-textures";
 import type { FabricType } from "../../lib/fabric-textures";
@@ -53,6 +58,44 @@ export default function Toolbar({ onExport }: ToolbarProps) {
   const setViewSide = useUIStore((s) => s.setViewSide);
   const activePanel = useUIStore((s) => s.activePanel);
   const togglePanel = useUIStore((s) => s.togglePanel);
+
+  const undo = useDesignStore((s) => s.undo);
+  const redo = useDesignStore((s) => s.redo);
+  const canUndo = useDesignStore((s) => s.canUndo);
+  const canRedo = useDesignStore((s) => s.canRedo);
+  const saveToLocal = useDesignStore((s) => s.saveToLocal);
+  const loadFromLocal = useDesignStore((s) => s.loadFromLocal);
+  const saveDesign = useDesignStore((s) => s.saveDesign);
+  const loadDesign = useDesignStore((s) => s.loadDesign);
+
+  const handleSaveFile = () => {
+    const json = saveDesign();
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "garment-design.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleLoadFile = () => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json";
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === "string") {
+          loadDesign(reader.result);
+        }
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  };
 
   return (
     <div className="absolute top-4 left-4 flex flex-col gap-2 z-10">
@@ -136,14 +179,65 @@ export default function Toolbar({ onExport }: ToolbarProps) {
         ))}
       </div>
 
-      {/* Export */}
-      <button
-        onClick={onExport}
-        className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-indigo-500 hover:bg-indigo-400 text-white text-xs font-medium transition-colors"
-      >
-        <Download size={14} />
-        Export
-      </button>
+      {/* Undo/Redo + Save/Load */}
+      <div className="flex gap-1 rounded-lg bg-[#1a1a1a]/90 backdrop-blur-sm p-1 border border-[#2a2a2a]">
+        <button
+          onClick={undo}
+          disabled={!canUndo()}
+          title="Undo (Ctrl+Z)"
+          className="px-2.5 py-1.5 rounded-md text-xs transition-colors disabled:text-gray-600 text-gray-400 hover:text-white hover:bg-white/10"
+        >
+          <Undo2 size={14} />
+        </button>
+        <button
+          onClick={redo}
+          disabled={!canRedo()}
+          title="Redo (Ctrl+Y)"
+          className="px-2.5 py-1.5 rounded-md text-xs transition-colors disabled:text-gray-600 text-gray-400 hover:text-white hover:bg-white/10"
+        >
+          <Redo2 size={14} />
+        </button>
+        <div className="w-px bg-[#2a2a2a]" />
+        <button
+          onClick={saveToLocal}
+          title="Quick Save"
+          className="px-2.5 py-1.5 rounded-md text-xs text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          <Save size={14} />
+        </button>
+        <button
+          onClick={loadFromLocal}
+          title="Quick Load"
+          className="px-2.5 py-1.5 rounded-md text-xs text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          <FolderOpen size={14} />
+        </button>
+      </div>
+
+      {/* Export + File operations */}
+      <div className="flex gap-1">
+        <button
+          onClick={onExport}
+          className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-indigo-500 hover:bg-indigo-400 text-white text-xs font-medium transition-colors"
+        >
+          <Download size={14} />
+          Export
+        </button>
+        <button
+          onClick={handleSaveFile}
+          title="Save as JSON"
+          className="px-3 py-2 rounded-lg bg-[#1a1a1a]/90 border border-[#2a2a2a] text-gray-400 hover:text-white text-xs transition-colors"
+        >
+          <Save size={14} />
+        </button>
+        <button
+          onClick={handleLoadFile}
+          title="Load JSON"
+          className="px-3 py-2 rounded-lg bg-[#1a1a1a]/90 border border-[#2a2a2a] text-gray-400 hover:text-white text-xs transition-colors"
+        >
+          <FolderOpen size={14} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/store/useDesignStore.ts
+++ b/src/store/useDesignStore.ts
@@ -1,9 +1,15 @@
 import { create } from "zustand";
 import type { DesignElement, TextElement, ImageElement } from "../types/design";
 
+const MAX_HISTORY = 50;
+
 interface DesignState {
   elements: DesignElement[];
   selectedId: string | null;
+
+  // History
+  _history: DesignElement[][];
+  _future: DesignElement[][];
 
   addText: (text: Partial<TextElement> & { text: string }) => void;
   addImage: (img: Partial<ImageElement> & { src: string; fileName: string }) => void;
@@ -11,14 +17,31 @@ interface DesignState {
   removeElement: (id: string) => void;
   selectElement: (id: string | null) => void;
   clearAll: () => void;
+
+  undo: () => void;
+  redo: () => void;
+  canUndo: () => boolean;
+  canRedo: () => boolean;
+
+  saveDesign: () => string;
+  loadDesign: (json: string) => void;
+  saveToLocal: () => void;
+  loadFromLocal: () => boolean;
 }
 
 let nextId = 1;
 const genId = () => `el-${nextId++}`;
 
-export const useDesignStore = create<DesignState>((set) => ({
+function pushHistory(state: DesignState): Pick<DesignState, "_history" | "_future"> {
+  const history = [...state._history, state.elements].slice(-MAX_HISTORY);
+  return { _history: history, _future: [] };
+}
+
+export const useDesignStore = create<DesignState>((set, get) => ({
   elements: [],
   selectedId: null,
+  _history: [],
+  _future: [],
 
   addText: (partial) => {
     const el: TextElement = {
@@ -35,7 +58,11 @@ export const useDesignStore = create<DesignState>((set) => ({
       side: partial.side ?? "front",
       visible: partial.visible ?? true,
     };
-    set((s) => ({ elements: [...s.elements, el], selectedId: el.id }));
+    set((s) => ({
+      ...pushHistory(s),
+      elements: [...s.elements, el],
+      selectedId: el.id,
+    }));
   },
 
   addImage: (partial) => {
@@ -52,11 +79,16 @@ export const useDesignStore = create<DesignState>((set) => ({
       side: partial.side ?? "front",
       visible: partial.visible ?? true,
     };
-    set((s) => ({ elements: [...s.elements, el], selectedId: el.id }));
+    set((s) => ({
+      ...pushHistory(s),
+      elements: [...s.elements, el],
+      selectedId: el.id,
+    }));
   },
 
   updateElement: (id, updates) =>
     set((s) => ({
+      ...pushHistory(s),
       elements: s.elements.map((el) =>
         el.id === id ? ({ ...el, ...updates } as DesignElement) : el
       ),
@@ -64,11 +96,84 @@ export const useDesignStore = create<DesignState>((set) => ({
 
   removeElement: (id) =>
     set((s) => ({
+      ...pushHistory(s),
       elements: s.elements.filter((el) => el.id !== id),
       selectedId: s.selectedId === id ? null : s.selectedId,
     })),
 
   selectElement: (id) => set({ selectedId: id }),
 
-  clearAll: () => set({ elements: [], selectedId: null }),
+  clearAll: () =>
+    set((s) => ({
+      ...pushHistory(s),
+      elements: [],
+      selectedId: null,
+    })),
+
+  undo: () =>
+    set((s) => {
+      if (s._history.length === 0) return s;
+      const previous = s._history[s._history.length - 1];
+      return {
+        _history: s._history.slice(0, -1),
+        _future: [s.elements, ...s._future],
+        elements: previous,
+        selectedId: null,
+      };
+    }),
+
+  redo: () =>
+    set((s) => {
+      if (s._future.length === 0) return s;
+      const next = s._future[0];
+      return {
+        _history: [...s._history, s.elements],
+        _future: s._future.slice(1),
+        elements: next,
+        selectedId: null,
+      };
+    }),
+
+  canUndo: () => get()._history.length > 0,
+  canRedo: () => get()._future.length > 0,
+
+  saveDesign: () => {
+    const { elements } = get();
+    return JSON.stringify({ version: 1, elements }, null, 2);
+  },
+
+  loadDesign: (json: string) => {
+    try {
+      const data = JSON.parse(json);
+      if (data.version === 1 && Array.isArray(data.elements)) {
+        set((s) => ({
+          ...pushHistory(s),
+          elements: data.elements,
+          selectedId: null,
+        }));
+        // Update nextId to avoid collisions
+        const maxId = data.elements.reduce((max: number, el: DesignElement) => {
+          const num = parseInt(el.id.replace("el-", ""), 10);
+          return isNaN(num) ? max : Math.max(max, num);
+        }, 0);
+        nextId = maxId + 1;
+      }
+    } catch {
+      console.warn("Failed to load design JSON");
+    }
+  },
+
+  saveToLocal: () => {
+    const json = get().saveDesign();
+    localStorage.setItem("garment-design", json);
+  },
+
+  loadFromLocal: () => {
+    const json = localStorage.getItem("garment-design");
+    if (json) {
+      get().loadDesign(json);
+      return true;
+    }
+    return false;
+  },
 }));


### PR DESCRIPTION
## Summary
- Undo/Redo with history stack (max 50) + Ctrl+Z/Y keyboard shortcuts
- Quick save to localStorage + JSON file export/import
- Font selector with 7 Google Fonts (including Korean support)

## Test plan
- [ ] Add text elements, then Ctrl+Z to undo — element removed
- [ ] Ctrl+Y to redo — element restored
- [ ] Click Save icon — design persists after page reload via Quick Load
- [ ] Export/Import JSON — design transfers between sessions
- [ ] Select different fonts in TextPanel — rendered correctly on garment

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)