### PR TITLE
fix: pnpm version conflict in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Remove explicit pnpm version from workflow — uses `packageManager` field in package.json instead
- Fixes deploy failure: `Multiple versions of pnpm specified`

## Test plan
- [ ] After merge, "Deploy to GitHub Pages" workflow succeeds
- [ ] https://shinatga.github.io loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)